### PR TITLE
fixed redstone connections for diode and limiter

### DIFF
--- a/src/main/java/pl/amon/moretinygates/MoreTinyGates.java
+++ b/src/main/java/pl/amon/moretinygates/MoreTinyGates.java
@@ -1,6 +1,5 @@
 package pl.amon.moretinygates;
 
-import net.minecraft.world.item.Item;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;

--- a/src/main/java/pl/amon/moretinygates/blocks/DiodeBlock.java
+++ b/src/main/java/pl/amon/moretinygates/blocks/DiodeBlock.java
@@ -1,5 +1,7 @@
 package pl.amon.moretinygates.blocks;
 
+import com.dannyandson.tinygates.blocks.Side;
+
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -7,7 +9,7 @@ import net.minecraftforge.registries.DeferredRegister;
 
 public class DiodeBlock extends GateBlock {
   public DiodeBlock(DeferredRegister<Item> ITEMS, DeferredRegister<Block> BLOCKS, DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES) {
-    super("diode", ITEMS, BLOCKS, BLOCK_ENTITIES);
+    super("diode", ITEMS, BLOCKS, BLOCK_ENTITIES, (Side side) -> side == Side.BACK || side == Side.FRONT);
   }
 
   @Override

--- a/src/main/java/pl/amon/moretinygates/blocks/GateBlock.java
+++ b/src/main/java/pl/amon/moretinygates/blocks/GateBlock.java
@@ -1,6 +1,7 @@
 package pl.amon.moretinygates.blocks;
 
 import java.util.function.Supplier;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import com.dannyandson.tinygates.blocks.AbstractGateBlock;
@@ -34,7 +35,13 @@ public abstract class GateBlock {
     item = ITEMS.register(name + "_item", () -> new GateBlockItem(block.get()));
     entity = BLOCK_ENTITIES.register(name + "_block", this.createSupplier(name, block));
   }
-  
+
+  public GateBlock(String name, DeferredRegister<Item> ITEMS, DeferredRegister<Block> BLOCKS, DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES, Function<Side, Boolean> canConnectRedstoneFn) {
+    block = BLOCKS.register(name + "_block", () -> new VariantBlock(name,canConnectRedstoneFn));
+    item = ITEMS.register(name + "_item", () -> new GateBlockItem(block.get()));
+    entity = BLOCK_ENTITIES.register(name + "_block", this.createSupplier(name, block));
+  }
+
   public int runLogicOnSites(int left, int right, int back, int front) {
     return logic(left, right);
   }
@@ -57,10 +64,18 @@ public abstract class GateBlock {
 
   public class VariantBlock extends AbstractGateBlock {
     String name;
+    Function<Side, Boolean> canConnectRedstoneFn;
 
     public VariantBlock(String name) {
       super();
       this.name = name;
+      this.canConnectRedstoneFn = (Side side) -> side == Side.LEFT || side == Side.RIGHT || side == Side.FRONT;
+    }
+
+    public VariantBlock(String name,Function<Side, Boolean> canConnectRedstoneFn) {
+      super();
+      this.name = name;
+      this.canConnectRedstoneFn = canConnectRedstoneFn;
     }
 
     @Override
@@ -70,7 +85,7 @@ public abstract class GateBlock {
 
     @Override
     public boolean canConnectRedstone(Side side) {
-      return side == Side.LEFT || side == Side.RIGHT || side == Side.FRONT;
+      return canConnectRedstoneFn.apply(side);
     }
   }
 

--- a/src/main/java/pl/amon/moretinygates/blocks/GeneratorBlock.java
+++ b/src/main/java/pl/amon/moretinygates/blocks/GeneratorBlock.java
@@ -7,7 +7,6 @@ import com.dannyandson.tinygates.blocks.Side;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;

--- a/src/main/java/pl/amon/moretinygates/blocks/LimiterBlock.java
+++ b/src/main/java/pl/amon/moretinygates/blocks/LimiterBlock.java
@@ -1,5 +1,7 @@
 package pl.amon.moretinygates.blocks;
 
+import com.dannyandson.tinygates.blocks.Side;
+
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -7,7 +9,7 @@ import net.minecraftforge.registries.DeferredRegister;
 
 public class LimiterBlock extends GateBlock {
   public LimiterBlock(DeferredRegister<Item> ITEMS, DeferredRegister<Block> BLOCKS, DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES) {
-    super("limiter", ITEMS, BLOCKS, BLOCK_ENTITIES);
+    super("limiter", ITEMS, BLOCKS, BLOCK_ENTITIES, (Side side) -> side == Side.BACK || side == Side.FRONT || side == Side.RIGHT);
   }
 
   @Override


### PR DESCRIPTION
Redstone was connecting to diode (the big one) at the front and at the sides instead of the front and back. I patched it so it connects properly.

I have 0 experience with modding and I'm not a java developer so it might not be the prettiest fix, but it seems to work.